### PR TITLE
Add Ollama service integration

### DIFF
--- a/backend/services/ollama_service.py
+++ b/backend/services/ollama_service.py
@@ -1,0 +1,307 @@
+import json
+import logging
+import re
+from collections.abc import AsyncGenerator, Awaitable, Callable
+
+import httpx
+
+from config import settings
+
+logger = logging.getLogger(__name__)
+
+# ── Prompt templates ────────────────────────────────────────────────────────
+
+_QUERY_TEMPLATE = """\
+You are a code assistant. Answer the developer's question using ONLY the repository context below. Do not use external knowledge or invent information not present in the context. If the context does not contain enough information to answer, say so.
+
+--- Repository Context ---
+{context}
+--- End Context ---
+
+Question: {question}
+
+Answer:"""
+
+_CHAT_TEMPLATE = """\
+You are a code assistant helping a developer understand a GitHub repository. Use ONLY the information from the Repository Context below. Do not use external knowledge or invent details not in the context. If the answer is not in the context, say so.
+
+--- Repository Context ---
+{context}
+--- End Context ---
+
+{history}User: {message}
+Assistant:"""
+
+_ANALYZE_TEMPLATE = """\
+You are a code assistant. Analyze this GitHub repository using ONLY the context below. Base your summary strictly on the provided context; do not add external knowledge.
+
+--- Repository Context ---
+{context}
+--- End Context ---
+
+Provide a concise analysis covering:
+1. What this project does (2-3 sentences)
+2. Main technologies and frameworks used
+3. Key architectural patterns or structure
+4. How a developer would get started
+
+Be brief and practical."""
+
+_SECURITY_TEMPLATE = """\
+You are a security-focused code reviewer. Analyze the repository for security issues using ONLY the context below. Base findings only on code and patterns present in the context.
+
+--- Repository Context ---
+{context}
+--- End Context ---
+
+Identify and list:
+1. Potential security vulnerabilities (e.g. hardcoded secrets, SQL injection risks, insecure dependencies, exposed endpoints)
+2. Security best-practice violations
+3. Data exposure or privacy risks
+4. Recommended fixes for each finding
+
+Format each finding as:
+[SEVERITY: HIGH|MEDIUM|LOW] <Issue title>
+Description: <brief explanation>
+Recommendation: <what to do>
+
+If no issues are found, say "No significant security issues detected."
+Be specific and practical."""
+
+_EXPLAIN_TEMPLATE = """\
+You are a code assistant. Explain the following code using ONLY the Repository Context below. Do not infer or add information that is not in the context.
+
+--- Repository Context ---
+{context}
+--- End Context ---
+
+File/Code to explain: {file_path}
+
+Provide:
+1. What this file/code does (purpose and responsibility)
+2. Key functions, classes, or logic explained simply
+3. How it fits into the larger project
+4. Any important patterns or gotchas a developer should know
+
+Be clear and approachable."""
+
+_AGENTIC_TEMPLATE = """\
+You are a code assistant helping a developer understand a GitHub repository.
+You have access to one tool:
+  FETCH_FILE(path) — retrieves the content of a specific file from the repository
+
+When you need a file to answer the question, respond with EXACTLY this (nothing else):
+  FETCH_FILE(relative/path/to/file)
+
+Rules:
+- Use FETCH_FILE only when the file content is required to answer.
+- You may call FETCH_FILE at most {max_calls} time(s).
+- When you have enough information, provide your complete answer directly.
+- Do NOT include FETCH_FILE in your final answer.
+- Base your answer only on what is provided below and any files you fetch.
+
+--- Repository Overview ---
+{general_context}
+--- End Overview ---
+
+{history}User: {message}
+Assistant:"""
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _format_history(history: list[dict]) -> str:
+    if not history:
+        return ""
+    lines: list[str] = []
+    for msg in history[-10:]:
+        role = "User" if msg["role"] == "user" else "Assistant"
+        lines.append(f"{role}: {msg['content']}")
+    return "Previous conversation:\n" + "\n".join(lines) + "\n\n"
+
+
+# ── Internal generators ──────────────────────────────────────────────────────
+
+async def _generate(prompt: str, num_ctx: int = 4096) -> str:
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        response = await client.post(
+            f"{settings.ollama_base_url}/api/generate",
+            json={
+                "model": settings.ollama_model,
+                "prompt": prompt,
+                "stream": False,
+                "options": {"num_ctx": num_ctx},
+            },
+        )
+        response.raise_for_status()
+        data: dict = response.json()
+    return data.get("response", "").strip() or "No response received from model."
+
+
+async def _stream_generate(prompt: str, num_ctx: int = 4096) -> AsyncGenerator[str, None]:
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        async with client.stream(
+            "POST",
+            f"{settings.ollama_base_url}/api/generate",
+            json={
+                "model": settings.ollama_model,
+                "prompt": prompt,
+                "stream": True,
+                "options": {"num_ctx": num_ctx},
+            },
+        ) as response:
+            response.raise_for_status()
+            async for line in response.aiter_lines():
+                if not line:
+                    continue
+                data: dict = json.loads(line)
+                if token := data.get("response"):
+                    yield token
+                if data.get("done"):
+                    return
+
+
+# ── Public API — legacy (analyze / security) ─────────────────────────────────
+
+async def ask_ollama(context: str, question: str) -> str:
+    return await _generate(_QUERY_TEMPLATE.format(context=context, question=question))
+
+
+async def chat_ollama(context: str, message: str, history: list[dict]) -> str:
+    prompt = _CHAT_TEMPLATE.format(
+        context=context,
+        history=_format_history(history),
+        message=message,
+    )
+    return await _generate(prompt)
+
+
+async def summarize_repo(context: str) -> str:
+    return await _generate(_ANALYZE_TEMPLATE.format(context=context))
+
+
+async def scan_security(context: str) -> str:
+    return await _generate(_SECURITY_TEMPLATE.format(context=context))
+
+
+async def explain_code(context: str, file_path: str) -> str:
+    return await _generate(_EXPLAIN_TEMPLATE.format(context=context, file_path=file_path))
+
+
+async def stream_chat_ollama(
+    context: str, message: str, history: list[dict]
+) -> AsyncGenerator[str, None]:
+    prompt = _CHAT_TEMPLATE.format(
+        context=context,
+        history=_format_history(history),
+        message=message,
+    )
+    async for token in _stream_generate(prompt):
+        yield token
+
+
+# ── Public API — agentic tool-use loop ───────────────────────────────────────
+
+async def agentic_chat(
+    general_context: str,
+    message: str,
+    history: list[dict],
+    fetch_file_fn: Callable[[str], Awaitable[str]],
+    max_tool_calls: int = 3,
+) -> str:
+    """
+    Agentic Q&A loop:
+    1. Send general repo overview + history + question to the LLM.
+    2. If the LLM responds with FETCH_FILE(path), fetch that file and re-prompt.
+    3. Repeat up to max_tool_calls times, then return the final answer.
+    """
+    base_prompt = _AGENTIC_TEMPLATE.format(
+        max_calls=max_tool_calls,
+        general_context=general_context,
+        history=_format_history(history),
+        message=message,
+    )
+
+    # Text accumulated after the initial prompt (tool calls + file content blocks)
+    accumulated = ""
+
+    for call_idx in range(max_tool_calls):
+        response = await _generate(base_prompt + accumulated, num_ctx=8192)
+        logger.debug("[Agent] Round %d response: %r", call_idx + 1, response[:300])
+
+        match = re.match(r"^\s*FETCH_FILE\(([^)]+)\)\s*$", response, re.IGNORECASE)
+        if not match:
+            return response
+
+        path = match.group(1).strip()
+        logger.debug("[Agent] Tool call %d: FETCH_FILE(%s)", call_idx + 1, path)
+        content = await fetch_file_fn(path)
+        accumulated += (
+            f" FETCH_FILE({path})\n"
+            f"[File: {path}]\n"
+            f"{content or '(file not found or empty)'}\n"
+            f"[End File]\n\n"
+        )
+
+    # Exhausted tool calls — generate final answer with all fetched context
+    logger.debug("[Agent] Exhausted tool calls, generating final answer")
+    return await _generate(base_prompt + accumulated, num_ctx=8192)
+
+
+async def stream_agentic_chat(
+    general_context: str,
+    message: str,
+    history: list[dict],
+    fetch_file_fn: Callable[[str], Awaitable[str]],
+    max_tool_calls: int = 3,
+) -> AsyncGenerator[dict, None]:
+    """
+    Streaming version of the agentic loop.
+    Yields dicts:  {"token": str}  for answer tokens
+                   {"status": str} for tool-use progress updates
+    Tool-use rounds run non-streaming so the full response can be inspected;
+    the final answer is streamed token by token.
+    """
+    base_prompt = _AGENTIC_TEMPLATE.format(
+        max_calls=max_tool_calls,
+        general_context=general_context,
+        history=_format_history(history),
+        message=message,
+    )
+
+    accumulated = ""
+
+    for call_idx in range(max_tool_calls):
+        response = await _generate(base_prompt + accumulated, num_ctx=8192)
+        logger.debug("[Agent] Stream round %d: %r", call_idx + 1, response[:300])
+
+        match = re.match(r"^\s*FETCH_FILE\(([^)]+)\)\s*$", response, re.IGNORECASE)
+        if not match:
+            # LLM gave a direct answer — yield it as a single token chunk
+            yield {"token": response}
+            return
+
+        path = match.group(1).strip()
+        logger.debug("[Agent] Stream tool call %d: FETCH_FILE(%s)", call_idx + 1, path)
+        yield {"status": f"Fetching file: {path}"}
+        content = await fetch_file_fn(path)
+        accumulated += (
+            f" FETCH_FILE({path})\n"
+            f"[File: {path}]\n"
+            f"{content or '(file not found or empty)'}\n"
+            f"[End File]\n\n"
+        )
+
+    # Stream the final answer after all tool calls
+    logger.debug("[Agent] Streaming final answer after tool calls")
+    async for token in _stream_generate(base_prompt + accumulated, num_ctx=8192):
+        yield {"token": token}
+
+
+async def check_connection() -> bool:
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        try:
+            resp = await client.get(f"{settings.ollama_base_url}/api/tags")
+            return resp.status_code == 200
+        except Exception:
+            return False


### PR DESCRIPTION
[Resolves JIRA GAA-20](https://eladglx.atlassian.net/browse/GAA-20?atlOrigin=eyJpIjoiMzkwNmRkMjdhYWFjNDZhNmJlMTMyNDBkNjNmMzM0YjkiLCJwIjoiaiJ9)

**Prompt templates and helpers:**
- Introduces multiple prompt templates for different tasks (Q&A, chat, repo analysis, security review, code explanation, and agentic tool-use), each enforcing strict context use and clear user/assistant roles. (_QUERY_TEMPLATE, _CHAT_TEMPLATE, _ANALYZE_TEMPLATE, _SECURITY_TEMPLATE, _EXPLAIN_TEMPLATE, _AGENTIC_TEMPLATE)
- Adds a `_format_history` helper to structure previous chat history for conversational context.

**LLM interaction (core generation):**
- Implements `_generate` and `_stream_generate` functions for non-streaming and streaming LLM responses, using `httpx.AsyncClient` for async HTTP requests to the Ollama backend.

**Public API for repository Q&A and analysis:**
- Exposes high-level async functions for tasks like `ask_ollama`