### PR TITLE
Use anthropic instead of Ollama

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,9 @@
 # GitHub API — optional, increases rate limit from 60 to 5000 req/hour
 GITHUB_TOKEN=
 
-# Ollama — uses container name when running via docker compose
-OLLAMA_BASE_URL=http://ollama:11434
-OLLAMA_MODEL=codellama:7b-instruct
+# Anthropic API
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-opus-4-6
 
 # Apache Kafka — uses container name when running via docker compose
 KAFKA_BOOTSTRAP_SERVERS=kafka:9092

--- a/backend/config.py
+++ b/backend/config.py
@@ -3,8 +3,8 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     github_token: str = ""
-    ollama_base_url: str = "http://localhost:11434"
-    ollama_model: str = "llama3"
+    anthropic_api_key: str = ""
+    anthropic_model: str = "claude-opus-4-6"
     kafka_bootstrap_servers: str = "localhost:9092"
     kafka_topic: str = "ai-events"
     database_url: str = ""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ aiokafka>=0.11.0
 pydantic>=2.8.0
 pydantic-settings>=2.4.0
 python-dotenv>=1.0.0
+anthropic>=0.40.0

--- a/backend/routers/analyze.py
+++ b/backend/routers/analyze.py
@@ -28,12 +28,12 @@ async def _run_analysis(request: AnalyzeRequest) -> AnalyzeResponse:
     timestamp = datetime.now(timezone.utc)
     repo_url_str = str(request.repo_url)
 
-    await emit_repo_analysis(repo_url_str, summary, settings.ollama_model)
+    await emit_repo_analysis(repo_url_str, summary, settings.anthropic_model)
     await log_event(
         event_type="analyze",
         repo_url=repo_url_str,
         ai_response=summary,
-        model_name=settings.ollama_model,
+        model_name=settings.anthropic_model,
     )
 
     return AnalyzeResponse(

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -33,7 +33,7 @@ async def _resolve_history(request: ChatRequest, repo_url_str: str) -> list[dict
 async def chat(request: ChatRequest) -> ChatResponse:
     repo_url_str = str(request.repo_url)
 
-    await emit_chat_request(repo_url_str, request.message, settings.ollama_model)
+    await emit_chat_request(repo_url_str, request.message, settings.anthropic_model)
 
     try:
         info = await fetch_repo_overview(request.repo_url)
@@ -57,11 +57,11 @@ async def chat(request: ChatRequest) -> ChatResponse:
         event_type="chat",
         repo_url=repo_url_str,
         ai_response=reply,
-        model_name=settings.ollama_model,
+        model_name=settings.anthropic_model,
         user_message=request.message,
         user_name=request.user_name or None,
     )
-    await emit_chat_response(repo_url_str, request.message, reply, settings.ollama_model)
+    await emit_chat_response(repo_url_str, request.message, reply, settings.anthropic_model)
 
     return ChatResponse(message=reply, timestamp=timestamp)
 
@@ -70,7 +70,7 @@ async def chat(request: ChatRequest) -> ChatResponse:
 async def chat_stream(request: ChatRequest) -> StreamingResponse:
     repo_url_str = str(request.repo_url)
 
-    await emit_chat_request(repo_url_str, request.message, settings.ollama_model)
+    await emit_chat_request(repo_url_str, request.message, settings.anthropic_model)
 
     try:
         info = await fetch_repo_overview(request.repo_url)
@@ -106,11 +106,11 @@ async def chat_stream(request: ChatRequest) -> StreamingResponse:
                 event_type="chat",
                 repo_url=repo_url_str,
                 ai_response=full_reply,
-                model_name=settings.ollama_model,
+                model_name=settings.anthropic_model,
                 user_message=request.message,
                 user_name=request.user_name or None,
             )
-            await emit_chat_response(repo_url_str, request.message, full_reply, settings.ollama_model)
+            await emit_chat_response(repo_url_str, request.message, full_reply, settings.anthropic_model)
         except Exception:
             pass
 

--- a/backend/routers/security.py
+++ b/backend/routers/security.py
@@ -35,13 +35,13 @@ async def security_scan(request: SecurityScanRequest) -> SecurityScanResponse:
     timestamp = datetime.now(timezone.utc)
     repo_url_str = str(request.repo_url)
 
-    await emit_security_scan(repo_url_str, finding_count, has_high, settings.ollama_model)
+    await emit_security_scan(repo_url_str, finding_count, has_high, settings.anthropic_model)
     await log_security_scan(
         repo_url=repo_url_str,
         findings_raw=findings_raw,
         finding_count=finding_count,
         has_high=has_high,
-        model_name=settings.ollama_model,
+        model_name=settings.anthropic_model,
     )
 
     return SecurityScanResponse(
@@ -75,7 +75,7 @@ async def analyze_code(request: AnalyzeCodeRequest) -> AnalyzeCodeResponse:
         event_type="code_explain",
         repo_url=repo_url_str,
         ai_response=explanation,
-        model_name=settings.ollama_model,
+        model_name=settings.anthropic_model,
         user_message=request.file_path,
     )
 

--- a/backend/services/ollama_service.py
+++ b/backend/services/ollama_service.py
@@ -1,13 +1,14 @@
-import json
 import logging
 import re
 from collections.abc import AsyncGenerator, Awaitable, Callable
 
-import httpx
+import anthropic
 
 from config import settings
 
 logger = logging.getLogger(__name__)
+
+_client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
 
 # ── Prompt templates ────────────────────────────────────────────────────────
 
@@ -123,42 +124,22 @@ def _format_history(history: list[dict]) -> str:
 # ── Internal generators ──────────────────────────────────────────────────────
 
 async def _generate(prompt: str, num_ctx: int = 4096) -> str:
-    async with httpx.AsyncClient(timeout=120.0) as client:
-        response = await client.post(
-            f"{settings.ollama_base_url}/api/generate",
-            json={
-                "model": settings.ollama_model,
-                "prompt": prompt,
-                "stream": False,
-                "options": {"num_ctx": num_ctx},
-            },
-        )
-        response.raise_for_status()
-        data: dict = response.json()
-    return data.get("response", "").strip() or "No response received from model."
+    message = await _client.messages.create(
+        model=settings.anthropic_model,
+        max_tokens=num_ctx,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return next((b.text for b in message.content if b.type == "text"), "No response received from model.")
 
 
 async def _stream_generate(prompt: str, num_ctx: int = 4096) -> AsyncGenerator[str, None]:
-    async with httpx.AsyncClient(timeout=120.0) as client:
-        async with client.stream(
-            "POST",
-            f"{settings.ollama_base_url}/api/generate",
-            json={
-                "model": settings.ollama_model,
-                "prompt": prompt,
-                "stream": True,
-                "options": {"num_ctx": num_ctx},
-            },
-        ) as response:
-            response.raise_for_status()
-            async for line in response.aiter_lines():
-                if not line:
-                    continue
-                data: dict = json.loads(line)
-                if token := data.get("response"):
-                    yield token
-                if data.get("done"):
-                    return
+    async with _client.messages.stream(
+        model=settings.anthropic_model,
+        max_tokens=num_ctx,
+        messages=[{"role": "user", "content": prompt}],
+    ) as stream:
+        async for text in stream.text_stream:
+            yield text
 
 
 # ── Public API — legacy (analyze / security) ─────────────────────────────────
@@ -299,9 +280,12 @@ async def stream_agentic_chat(
 
 
 async def check_connection() -> bool:
-    async with httpx.AsyncClient(timeout=5.0) as client:
-        try:
-            resp = await client.get(f"{settings.ollama_base_url}/api/tags")
-            return resp.status_code == 200
-        except Exception:
-            return False
+    try:
+        await _client.messages.create(
+            model=settings.anthropic_model,
+            max_tokens=10,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        return True
+    except Exception:
+        return False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,45 +24,6 @@ services:
       start_period: 20s
     restart: unless-stopped
 
-  ollama:
-    image: ollama/ollama:latest
-    container_name: ollama
-
-    ports:
-      - "11434:11434"
-
-    volumes:
-      - ollama_data:/root/.ollama
-      - ./scripts/ollama-entrypoint.sh:/entrypoint.sh:ro
-
-    env_file:
-      - .env
-
-    entrypoint: ["/bin/sh", "/entrypoint.sh"]
-
-    # 👇 זה החלק הקריטי ל-GPU
-    environment:
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
-
-    # 👇 זה חשוב מאוד (compose v2)
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
-
-    healthcheck:
-      test: ["CMD", "ollama", "list"]
-      interval: 15s
-      timeout: 10s
-      retries: 15
-      start_period: 45s
-
-    restart: unless-stopped
-
   backend:
     build:
       context: .
@@ -72,12 +33,9 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
-      ollama:
-        condition: service_started
     env_file:
       - .env
     environment:
-      OLLAMA_BASE_URL: http://ollama:11434
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
     healthcheck:
       test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/8000'"]
@@ -107,5 +65,3 @@ services:
       backend:
         condition: service_healthy
 
-volumes:
-  ollama_data:


### PR DESCRIPTION
This pull request migrates the backend AI integration from using the local Ollama service to Anthropic's Claude model. The change affects configuration, dependencies, service implementation, and deployment setup. All relevant environment variables, service calls, and Docker Compose settings have been updated to remove Ollama and introduce Anthropic support.

**AI Model Integration Migration:**

* Replaced all usage of Ollama (local LLM) with Anthropic Claude (`claude-opus-4-6`) in environment variables (`.env`), backend configuration (`config.py`), and all backend logic that references the model name or API keys.
* Updated the backend service implementation in `ollama_service.py` to use the Anthropic API client for both standard and streaming completions, removing all HTTP calls to Ollama and related logic. 
* Replaced all references to `settings.ollama_model` and related emit/logging calls in routers (`analyze.py`, `chat.py`, `security.py`) with `settings.anthropic_model`.

**Dependencies and Configuration:**

* Added the `anthropic` Python package to backend requirements.
* Updated the backend configuration to include Anthropic API key and model settings, removing Ollama-specific configuration.

**Deployment and Docker Compose:**

* Removed the Ollama service, its volumes, and all related configuration from `docker-compose.yml`, simplifying deployment and removing GPU requirements

**Service Health Checks:**

* Updated the backend's health check and startup dependencies to no longer wait for the Ollama service.

These changes fully transition the backend from a local LLM to a managed cloud-based LLM (Anthropic Claude), streamlining deployment and centralizing model configuration.