### PR TITLE
Fix erased context

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.0"
+    "react-router-dom": "^6.26.0",
+    "react-markdown": "^9.0.1",
+    "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -283,37 +283,29 @@ body {
   border-bottom-left-radius: 3px;
 }
 
-/* ── Markdown rendering inside assistant bubbles ── */
-.message.assistant .message-bubble > :first-child { margin-top: 0; }
-.message.assistant .message-bubble > :last-child  { margin-bottom: 0; }
+/* ── Shared markdown renderer (.md wrapper) ── */
+.md > :first-child { margin-top: 0; }
+.md > :last-child  { margin-bottom: 0; }
 
-.message.assistant .message-bubble p {
-  margin: 0 0 0.6rem;
-}
+.md p { margin: 0 0 0.6rem; }
 
-.message.assistant .message-bubble h1,
-.message.assistant .message-bubble h2,
-.message.assistant .message-bubble h3,
-.message.assistant .message-bubble h4 {
+.md h1, .md h2, .md h3, .md h4 {
   margin: 1rem 0 0.4rem;
   font-weight: 600;
   line-height: 1.3;
   color: var(--text);
 }
-.message.assistant .message-bubble h1 { font-size: 1.15rem; }
-.message.assistant .message-bubble h2 { font-size: 1.05rem; }
-.message.assistant .message-bubble h3 { font-size: 0.95rem; }
+.md h1 { font-size: 1.15rem; }
+.md h2 { font-size: 1.05rem; }
+.md h3 { font-size: 0.95rem; }
 
-.message.assistant .message-bubble ul,
-.message.assistant .message-bubble ol {
+.md ul, .md ol {
   margin: 0.4rem 0 0.6rem 1.4rem;
   padding: 0;
 }
-.message.assistant .message-bubble li {
-  margin-bottom: 0.2rem;
-}
+.md li { margin-bottom: 0.2rem; }
 
-.message.assistant .message-bubble code {
+.md code {
   font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
   font-size: 0.82rem;
   background: rgba(255,255,255,0.08);
@@ -322,7 +314,7 @@ body {
   padding: 0.1em 0.4em;
 }
 
-.message.assistant .message-bubble pre {
+.md pre {
   background: #0d1117;
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -330,7 +322,7 @@ body {
   overflow-x: auto;
   margin: 0.6rem 0;
 }
-.message.assistant .message-bubble pre code {
+.md pre code {
   background: none;
   border: none;
   padding: 0;
@@ -338,39 +330,50 @@ body {
   color: #e6edf3;
 }
 
-.message.assistant .message-bubble blockquote {
+.md blockquote {
   border-left: 3px solid var(--border);
   margin: 0.5rem 0;
   padding: 0.2rem 0.8rem;
   color: var(--text-muted);
 }
 
-.message.assistant .message-bubble table {
+.md table {
   border-collapse: collapse;
   width: 100%;
   margin: 0.6rem 0;
   font-size: 0.85rem;
 }
-.message.assistant .message-bubble th,
-.message.assistant .message-bubble td {
+.md th, .md td {
   border: 1px solid var(--border);
   padding: 0.4rem 0.7rem;
   text-align: left;
 }
-.message.assistant .message-bubble th {
+.md th {
   background: rgba(255,255,255,0.05);
   font-weight: 600;
 }
 
-.message.assistant .message-bubble a {
-  color: var(--accent);
-  text-decoration: underline;
-}
+.md a { color: var(--accent); text-decoration: underline; }
 
-.message.assistant .message-bubble hr {
+.md hr {
   border: none;
   border-top: 1px solid var(--border);
   margin: 0.75rem 0;
+}
+
+/* ── Thinking animation ── */
+.thinking-dots { color: var(--text-muted); font-style: italic; }
+.thinking-dots-trail {
+  display: inline-block;
+  width: 1.6ch;
+  text-align: left;
+}
+
+/* ── Analyze loading indicator ── */
+.analyze-loading {
+  margin-top: 1.5rem;
+  text-align: center;
+  font-size: 0.95rem;
 }
 
 .message-role {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -266,7 +266,6 @@ body {
   padding: 0.65rem 1rem;
   font-size: 0.9rem;
   line-height: 1.6;
-  white-space: pre-wrap;
   word-break: break-word;
 }
 
@@ -274,6 +273,7 @@ body {
   background: var(--user-bubble);
   color: #fff;
   border-bottom-right-radius: 3px;
+  white-space: pre-wrap;
 }
 
 .message.assistant .message-bubble {
@@ -281,6 +281,96 @@ body {
   border: 1px solid var(--border);
   color: var(--text);
   border-bottom-left-radius: 3px;
+}
+
+/* ── Markdown rendering inside assistant bubbles ── */
+.message.assistant .message-bubble > :first-child { margin-top: 0; }
+.message.assistant .message-bubble > :last-child  { margin-bottom: 0; }
+
+.message.assistant .message-bubble p {
+  margin: 0 0 0.6rem;
+}
+
+.message.assistant .message-bubble h1,
+.message.assistant .message-bubble h2,
+.message.assistant .message-bubble h3,
+.message.assistant .message-bubble h4 {
+  margin: 1rem 0 0.4rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--text);
+}
+.message.assistant .message-bubble h1 { font-size: 1.15rem; }
+.message.assistant .message-bubble h2 { font-size: 1.05rem; }
+.message.assistant .message-bubble h3 { font-size: 0.95rem; }
+
+.message.assistant .message-bubble ul,
+.message.assistant .message-bubble ol {
+  margin: 0.4rem 0 0.6rem 1.4rem;
+  padding: 0;
+}
+.message.assistant .message-bubble li {
+  margin-bottom: 0.2rem;
+}
+
+.message.assistant .message-bubble code {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.82rem;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.1em 0.4em;
+}
+
+.message.assistant .message-bubble pre {
+  background: #0d1117;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+  margin: 0.6rem 0;
+}
+.message.assistant .message-bubble pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.82rem;
+  color: #e6edf3;
+}
+
+.message.assistant .message-bubble blockquote {
+  border-left: 3px solid var(--border);
+  margin: 0.5rem 0;
+  padding: 0.2rem 0.8rem;
+  color: var(--text-muted);
+}
+
+.message.assistant .message-bubble table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 0.6rem 0;
+  font-size: 0.85rem;
+}
+.message.assistant .message-bubble th,
+.message.assistant .message-bubble td {
+  border: 1px solid var(--border);
+  padding: 0.4rem 0.7rem;
+  text-align: left;
+}
+.message.assistant .message-bubble th {
+  background: rgba(255,255,255,0.05);
+  font-weight: 600;
+}
+
+.message.assistant .message-bubble a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.message.assistant .message-bubble hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 0.75rem 0;
 }
 
 .message-role {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import NavBar from './components/NavBar'
 import AnalyzePage from './pages/AnalyzePage'
@@ -5,13 +6,26 @@ import ChatPage from './pages/ChatPage'
 import DashboardPage from './pages/DashboardPage'
 
 export default function App() {
+  // Lifted here so state survives tab navigation
+  const [repoUrl, setRepoUrl] = useState('')
+  const [userName, setUserName] = useState('')
+  const [activeRepo, setActiveRepo] = useState('')
+  const [messages, setMessages] = useState([])
+
   return (
     <BrowserRouter>
       <NavBar />
       <main className="main-content">
         <Routes>
           <Route path="/" element={<Navigate to="/chat" replace />} />
-          <Route path="/chat"      element={<ChatPage />} />
+          <Route path="/chat" element={
+            <ChatPage
+              repoUrl={repoUrl}       setRepoUrl={setRepoUrl}
+              userName={userName}     setUserName={setUserName}
+              activeRepo={activeRepo} setActiveRepo={setActiveRepo}
+              messages={messages}     setMessages={setMessages}
+            />
+          } />
           <Route path="/analyze"   element={<AnalyzePage />} />
           <Route path="/dashboard" element={<DashboardPage />} />
         </Routes>

--- a/frontend/src/components/ThinkingDots.jsx
+++ b/frontend/src/components/ThinkingDots.jsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+const DOTS = ['', '.', '..', '...']
+
+export default function ThinkingDots({ label = 'Thinking' }) {
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => setTick(t => (t + 1) % DOTS.length), 500)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <span className="thinking-dots">
+      {label}
+      <span className="thinking-dots-trail">{DOTS[tick]}</span>
+    </span>
+  )
+}

--- a/frontend/src/pages/AnalyzePage.jsx
+++ b/frontend/src/pages/AnalyzePage.jsx
@@ -1,4 +1,7 @@
 import { useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import ThinkingDots from '../components/ThinkingDots'
 import { analyzeRepo } from '../api/client'
 
 export default function AnalyzePage() {
@@ -38,9 +41,15 @@ export default function AnalyzePage() {
           required
         />
         <button className="btn" type="submit" disabled={loading}>
-          {loading ? 'Analyzing...' : 'Analyze'}
+          {loading ? <ThinkingDots label="Analyzing" /> : 'Analyze'}
         </button>
       </form>
+
+      {loading && (
+        <div className="analyze-loading">
+          <ThinkingDots label="Analyzing repository" />
+        </div>
+      )}
 
       {error && <div className="error-banner">{error}</div>}
 
@@ -65,7 +74,11 @@ export default function AnalyzePage() {
 
             <div className="result-section">
               <h3>AI Summary</h3>
-              <pre>{result.summary}</pre>
+              <div className="md">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {result.summary}
+                </ReactMarkdown>
+              </div>
             </div>
 
             {result.key_files.length > 0 && (

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import ThinkingDots from '../components/ThinkingDots'
 import { streamChatMessage } from '../api/client'
 
 export default function ChatPage({
@@ -109,9 +110,9 @@ export default function ChatPage({
             </span>
             <div className="message-bubble">
               {msg.role === 'assistant' ? (
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                  {msg.content || (loading && i === messages.length - 1 ? '_Thinking…_' : '')}
-                </ReactMarkdown>
+                msg.content === '' && loading && i === messages.length - 1
+                  ? <ThinkingDots label="Thinking" />
+                  : <div className="md"><ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown></div>
               ) : (
                 msg.content
               )}

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -1,11 +1,14 @@
 import { useEffect, useRef, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import { streamChatMessage } from '../api/client'
 
-export default function ChatPage() {
-  const [repoUrl, setRepoUrl] = useState('')
-  const [userName, setUserName] = useState('')
-  const [activeRepo, setActiveRepo] = useState('')
-  const [messages, setMessages] = useState([])
+export default function ChatPage({
+  repoUrl, setRepoUrl,
+  userName, setUserName,
+  activeRepo, setActiveRepo,
+  messages, setMessages,
+}) {
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -30,8 +33,7 @@ export default function ChatPage() {
     if (!text || !activeRepo || loading) return
 
     const historySnapshot = messages
-    const userMsg = { role: 'user', content: text }
-    const withUser = [...messages, userMsg]
+    const withUser = [...messages, { role: 'user', content: text }]
     setMessages([...withUser, { role: 'assistant', content: '' }])
     setInput('')
     setError('')
@@ -106,7 +108,13 @@ export default function ChatPage() {
               {msg.role === 'user' ? 'You' : 'Assistant'}
             </span>
             <div className="message-bubble">
-              {msg.content || (loading && i === messages.length - 1 ? 'Thinking...' : '')}
+              {msg.role === 'assistant' ? (
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {msg.content || (loading && i === messages.length - 1 ? '_Thinking…_' : '')}
+                </ReactMarkdown>
+              ) : (
+                msg.content
+              )}
             </div>
           </div>
         ))}


### PR DESCRIPTION
**Markdown rendering and styling:**

* Updated both `ChatPage` and `AnalyzePage` to render assistant and summary responses as markdown using the new libraries, replacing plain text or `<pre>` blocks. 
* Added extensive CSS styles for a `.md` class to provide consistent and attractive markdown formatting (headings, lists, code, tables, etc.).

**User experience improvements:**

* Added a reusable `ThinkingDots` component to display animated ellipsis during loading or "thinking" states, and integrated it into chat and analyze page loading indicators. 
* Improved loading feedback on the Analyze page with a dedicated loading indicator and clearer button state.

**State management and navigation:**

* Lifted chat-related state (`repoUrl`, `userName`, `activeRepo`, `messages`) up to the `App` component so that conversation state persists when navigating between tabs. Updated `ChatPage` to accept these as props.
**Other improvements:**

* Moved `white-space: pre-wrap` from the global message bubble style to only apply for user messages, to avoid interfering with markdown rendering.