### PR TITLE
FIX must put name befor loading repo

### DIFF
--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -21,6 +21,10 @@ export default function ChatPage({
 
   function loadRepo(e) {
     e.preventDefault()
+    if (!userName.trim()) {
+      setError('Please enter your name before loading a repository.')
+      return
+    }
     const trimmed = repoUrl.trim()
     if (!trimmed) return
     setActiveRepo(trimmed)
@@ -83,7 +87,7 @@ export default function ChatPage({
           onChange={(e) => setRepoUrl(e.target.value)}
           required
         />
-        <button className="btn btn-secondary" type="submit">
+        <button className="btn btn-secondary" type="submit" disabled={!userName.trim()}>
           Load repo
         </button>
       </form>


### PR DESCRIPTION
loadRepo guard — if userName is empty when the form is submitted, it sets an error message ("Please enter your name before loading a repository.") and returns early, preventing the repo from loading.

Button disabled state — the "Load repo" button is disabled (disabled={!userName.trim()}) whenever the name field is blank, giving an immediate visual cue that a name is required first.