### PR TITLE
Validate input

### DIFF
--- a/frontend/src/pages/AnalyzePage.jsx
+++ b/frontend/src/pages/AnalyzePage.jsx
@@ -3,6 +3,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import ThinkingDots from '../components/ThinkingDots'
 import { analyzeRepo } from '../api/client'
+import { isValidGitHubUrl } from '../utils/validateGitHubUrl'
 
 export default function AnalyzePage() {
   const [repoUrl, setRepoUrl] = useState('')
@@ -14,6 +15,10 @@ export default function AnalyzePage() {
     e.preventDefault()
     const trimmed = repoUrl.trim()
     if (!trimmed || loading) return
+    if (!isValidGitHubUrl(trimmed)) {
+      setError('Please enter a valid GitHub repository URL, e.g. https://github.com/owner/repo')
+      return
+    }
 
     setLoading(true)
     setError('')

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -3,6 +3,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import ThinkingDots from '../components/ThinkingDots'
 import { streamChatMessage } from '../api/client'
+import { isValidGitHubUrl } from '../utils/validateGitHubUrl'
 
 export default function ChatPage({
   repoUrl, setRepoUrl,
@@ -23,6 +24,10 @@ export default function ChatPage({
     e.preventDefault()
     const trimmed = repoUrl.trim()
     if (!trimmed) return
+    if (!isValidGitHubUrl(trimmed)) {
+      setError('Please enter a valid GitHub repository URL, e.g. https://github.com/owner/repo')
+      return
+    }
     setActiveRepo(trimmed)
     setMessages([])
     setError('')

--- a/frontend/src/utils/validateGitHubUrl.js
+++ b/frontend/src/utils/validateGitHubUrl.js
@@ -1,0 +1,11 @@
+const GITHUB_REPO_PATTERN = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+(\/.*)?$/
+
+/**
+ * Returns true only if `url` matches the expected GitHub repository URL shape:
+ * https://github.com/<owner>/<repo>[/anything]
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function isValidGitHubUrl(url) {
+  return GITHUB_REPO_PATTERN.test(url.trim())
+}


### PR DESCRIPTION
New file — src/utils/validateGitHubUrl.js

A single exported function isValidGitHubUrl(url) that uses the regex:

^https://github\.com/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+(/.*)?$
It enforces:

https:// protocol (no http:// or protocol-relative URLs)
Host must be exactly github.com
At least two path segments (owner + repo), each using valid GitHub name characters
Any deeper path is allowed (e.g. /tree/main, /issues)
ChatPage.jsx — loadRepo

After the empty-check, calls isValidGitHubUrl. If it fails, the existing error banner displays the message and the function returns early — no activeRepo is set and no backend request is made.

AnalyzePage.jsx — handleSubmit

Same pattern: validation runs before setLoading(true), so neither the loading state nor the API call is triggered on an invalid URL. The existing error banner shows the message.