### PR TITLE
Implement UI Loading States

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -361,8 +361,36 @@ body {
   margin: 0.75rem 0;
 }
 
+/* ── Spinner ── */
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+.spinner--lg {
+  width: 32px;
+  height: 32px;
+  border-width: 3px;
+}
+
 /* ── Thinking animation ── */
-.thinking-dots { color: var(--text-muted); font-style: italic; }
+.thinking-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
 .thinking-dots-trail {
   display: inline-block;
   width: 1.6ch;
@@ -371,8 +399,11 @@ body {
 
 /* ── Analyze loading indicator ── */
 .analyze-loading {
-  margin-top: 1.5rem;
-  text-align: center;
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.85rem;
   font-size: 0.95rem;
 }
 

--- a/frontend/src/components/ThinkingDots.jsx
+++ b/frontend/src/components/ThinkingDots.jsx
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react'
 
 const DOTS = ['', '.', '..', '...']
 
-export default function ThinkingDots({ label = 'Thinking' }) {
+/**
+ * @param {{ label?: string, spinner?: boolean }} props
+ * @returns {JSX.Element}
+ */
+export default function ThinkingDots({ label = 'Thinking', spinner = false }) {
   const [tick, setTick] = useState(0)
 
   useEffect(() => {
@@ -12,6 +16,7 @@ export default function ThinkingDots({ label = 'Thinking' }) {
 
   return (
     <span className="thinking-dots">
+      {spinner && <span className="spinner" aria-hidden="true" />}
       {label}
       <span className="thinking-dots-trail">{DOTS[tick]}</span>
     </span>

--- a/frontend/src/pages/AnalyzePage.jsx
+++ b/frontend/src/pages/AnalyzePage.jsx
@@ -41,12 +41,13 @@ export default function AnalyzePage() {
           required
         />
         <button className="btn" type="submit" disabled={loading}>
-          {loading ? <ThinkingDots label="Analyzing" /> : 'Analyze'}
+          {loading ? <ThinkingDots label="Analyzing" spinner /> : 'Analyze'}
         </button>
       </form>
 
       {loading && (
         <div className="analyze-loading">
+          <span className="spinner spinner--lg" aria-hidden="true" />
           <ThinkingDots label="Analyzing repository" />
         </div>
       )}

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -111,7 +111,7 @@ export default function ChatPage({
             <div className="message-bubble">
               {msg.role === 'assistant' ? (
                 msg.content === '' && loading && i === messages.length - 1
-                  ? <ThinkingDots label="Thinking" />
+                  ? <ThinkingDots label="Thinking" spinner />
                   : <div className="md"><ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown></div>
               ) : (
                 msg.content

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { getAnalytics } from '../api/client'
+import ThinkingDots from '../components/ThinkingDots'
 
 const PERIODS = [7, 30, 90]
 
@@ -71,7 +72,12 @@ export default function DashboardPage() {
 
       {error && <div className="error-banner">{error}</div>}
 
-      {loading && <p className="status-text">Loading analytics...</p>}
+      {loading && (
+        <div className="analyze-loading">
+          <span className="spinner spinner--lg" aria-hidden="true" />
+          <ThinkingDots label="Loading analytics" spinner={false} />
+        </div>
+      )}
 
       {!loading && data && (
         <>


### PR DESCRIPTION
App.css — added a @keyframes spin animation and two new classes:

.spinner — a 14px rotating ring for inline use (inside buttons, chat bubbles)
.spinner--lg — a 32px ring for page-level loading states
Updated .thinking-dots to display: inline-flex so the spinner aligns vertically with the text
Updated .analyze-loading to a centered flex column so the big spinner and label stack neatly
ThinkingDots.jsx — added an optional spinner boolean prop (default false). When true, a .spinner ring is rendered before the label text.

ChatPage.jsx — the assistant's empty "thinking" bubble now uses <ThinkingDots label="Thinking" spinner />, so there's a spinning ring next to the animated dots while waiting for the first token.

AnalyzePage.jsx — the submit button shows <ThinkingDots label="Analyzing" spinner />, and the page-level loading block now shows a large .spinner--lg ring above the "Analyzing repository..." text — far more visible during the long AI call.

DashboardPage.jsx — replaced the plain italic <p>Loading analytics...</p> with the same large-spinner + ThinkingDots pattern used on AnalyzePage.