### PR TITLE
Suit the project to make it run on render

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY backend/ .
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/services/kafka_service.py
+++ b/backend/services/kafka_service.py
@@ -44,6 +44,9 @@ async def _retry_loop() -> None:
 
 async def init_kafka() -> None:
     global _retry_task
+    if not settings.kafka_bootstrap_servers:
+        logger.info("KAFKA_BOOTSTRAP_SERVERS not configured — Kafka disabled")
+        return
     connected = await _connect()
     if not connected:
         logger.warning("Kafka not available at startup — will retry in background")

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,4 +1,4 @@
-const BASE = '/api'
+const BASE = (import.meta.env.VITE_API_URL ?? '') + '/api'
 
 async function post(path, body) {
   const res = await fetch(`${BASE}${path}`, {

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,35 @@
+services:
+  - type: web
+    name: github-ai-backend
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
+    envVars:
+      - key: ANTHROPIC_API_KEY
+        sync: false
+      - key: ANTHROPIC_MODEL
+        value: claude-opus-4-6
+      - key: DATABASE_URL
+        sync: false
+      - key: GITHUB_TOKEN
+        sync: false
+      - key: KAFKA_BOOTSTRAP_SERVERS
+        value: ""
+      - key: KAFKA_TOPIC
+        value: ai-events
+      - key: CHAT_HISTORY_SIZE
+        value: "10"
+
+  - type: web
+    name: github-ai-frontend
+    runtime: static
+    buildCommand: npm install && npm run build
+    staticPublishPath: ./dist
+    rootDir: frontend
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html
+    envVars:
+      - key: VITE_API_URL
+        sync: false


### PR DESCRIPTION
render.yaml (new) — Render Blueprint defining two services:

github-ai-backend — Docker Web Service built from the root Dockerfile; secrets (ANTHROPIC_API_KEY, DATABASE_URL, GITHUB_TOKEN) are marked sync: false so you enter them in the Render dashboard
github-ai-frontend — Static Site built with npm run build from the frontend/ directory, with SPA rewrite rule so React Router works
Dockerfile — Changed the CMD to use Render's injected PORT env var:

CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]
frontend/src/api/client.js — API base URL now reads VITE_API_URL at build time:

const BASE = (import.meta.env.VITE_API_URL ?? '') + '/api'
Locally: VITE_API_URL is not set → falls back to '' → Vite dev proxy handles /api as before
On Render: set VITE_API_URL to your backend's public URL (e.g. https://github-ai-backend.onrender.com)
backend/services/kafka_service.py — Skips Kafka entirely when KAFKA_BOOTSTRAP_SERVERS is empty, avoiding endless retry loops on Render

After deploying to Render, set these env vars in the dashboard:

ANTHROPIC_API_KEY — your Anthropic key
DATABASE_URL — your Neon connection string
GITHUB_TOKEN — optional, for higher rate limits
VITE_API_URL — the public URL of your deployed backend (e.g. https://github-ai-backend.onrender.com) — set this on the frontend service before building